### PR TITLE
bump healthcheck to fix feedback endpoint

### DIFF
--- a/healthcheck.tf
+++ b/healthcheck.tf
@@ -1,5 +1,5 @@
 locals {
-  healthcheck_build_num = 14
+  healthcheck_build_num = 15
 }
 
 resource "kubernetes_namespace" "healthcheck" {


### PR DESCRIPTION
This should fix the endpoint - was missing `/v1/health` for the config url.
