### PR TITLE
deploy scrapedumper

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: kube-services
 
 defaults:
   image: &default_image
-    hashicorp/terraform:0.13.3
+    hashicorp/terraform:0.13.5
   env: &default_env
     KUBE_LOAD_CONFIG_FILE: false
     TF_VAR_services_domain:

--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -1,0 +1,104 @@
+variable "name" {
+  type = string
+}
+variable "namespace" {
+  type = string
+}
+variable "image" {
+  type = string
+}
+variable "env" {
+  type    = map
+  default = {}
+}
+variable "schedule" {
+  type = string
+}
+variable "files" {
+  type = map(object({
+    target   = string
+    template = string
+    vars     = map(string)
+  }))
+  default = {}
+}
+
+resource "kubernetes_config_map" "files" {
+  for_each = var.files
+
+  metadata {
+    name      = "files-${var.name}-${each.key}"
+    namespace = var.namespace
+  }
+
+  data = {
+    "file" = templatefile("templates/${each.value.template}", each.value.vars)
+  }
+}
+
+resource "kubernetes_cron_job" "cron_job" {
+  metadata {
+    name      = var.name
+    namespace = var.namespace
+  }
+
+  spec {
+    schedule = var.schedule
+
+    concurrency_policy        = "Forbid"
+    starting_deadline_seconds = 30
+
+    failed_jobs_history_limit     = 10
+    successful_jobs_history_limit = 10
+
+    job_template {
+      metadata {
+        labels = { app = var.name }
+      }
+
+      spec {
+        backoff_limit = 3
+
+        template {
+          metadata {
+            labels = { app = var.name }
+          }
+
+          spec {
+            container {
+              image = var.image
+              name  = var.name
+
+              dynamic "env" {
+                for_each = var.env
+                content {
+                  name  = env.key
+                  value = env.value
+                }
+              }
+
+              dynamic "volume_mount" {
+                for_each = var.files
+                content {
+                  name       = volume_mount.key
+                  mount_path = volume_mount.value.target
+                  sub_path   = basename(volume_mount.value.target)
+                }
+              }
+            }
+
+            dynamic "volume" {
+              for_each = var.files
+              content {
+                name = volume.key
+                config_map {
+                  name = kubernetes_config_map.files[volume.key].metadata.0.name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/deployment/main.tf
+++ b/modules/deployment/main.tf
@@ -80,7 +80,7 @@ resource "kubernetes_deployment" "deployment" {
             content {
               name       = volume_mount.key
               mount_path = volume_mount.value.target
-              sub_path   = basename(volume_mount.value.target)
+              sub_path   = "file"
             }
           }
         }

--- a/templates/scrapedumper.yaml
+++ b/templates/scrapedumper.yaml
@@ -1,0 +1,6 @@
+{
+  "train_dumper": {
+    "kind": "POSTGRES",
+    "postgres_connection_string": "${pg_connection_string}"
+  }
+}


### PR DESCRIPTION
1. Update the `deployment` module to support mounting files from templates
1. Add a deployment module for the scrapedumper daemon. Point it to the third-rail database
1. Add a cron job for the scrapereaper, which cleans out the data on a nightly basis